### PR TITLE
Implement digital scale OCR recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Digital Scale Reader
+
+This tool captures weight readings from a jewelry scale's LCD display using a webcam. It uses OCR (Tesseract) to read the digits and records each change in weight.
+
+## Requirements
+
+* Python 3.10+
+* Tesseract OCR installed and accessible in your `PATH`
+* Python packages listed in `requirements.txt`
+
+Install packages via:
+
+```bash
+pip install -r requirements.txt
+```
+
+On Debian/Ubuntu systems, you can install Tesseract with:
+
+```bash
+sudo apt-get install tesseract-ocr
+```
+
+## Usage
+
+```bash
+python scale_reader.py output.csv --roi X Y W H --camera 0
+```
+
+Arguments:
+
+- `output.csv`: Path to a CSV file where readings will be written. A matching Excel file (`.xlsx`) is also generated.
+- `--roi X Y W H`: Optional. Defines the region of interest containing the LCD display (top-left `X`,`Y` coordinates and width `W`/height `H`). If not provided, the full frame is used.
+- `--camera N`: Optional. Index of the webcam to use (default `0`).
+
+While the program is running, a window shows the cropped display. Press `q` to stop recording. Each time a different weight reading is detected, it is logged with a timestamp.
+
+## Example
+
+```bash
+python scale_reader.py weights.csv --roi 100 150 200 80
+```
+
+This records scale readings to `weights.csv` and `weights.xlsx`, using the specified ROI.

--- a/main
+++ b/main
@@ -1,1 +1,4 @@
-#this is main
+#!/bin/bash
+# Simple wrapper to run the scale reader
+
+python3 scale_reader.py "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python-headless
+pytesseract
+pandas
+openpyxl

--- a/scale_reader.py
+++ b/scale_reader.py
@@ -1,0 +1,84 @@
+import cv2
+import pytesseract
+import pandas as pd
+from datetime import datetime
+import argparse
+
+
+def capture_scale(output_csv: str, display_roi=None, camera_index=0):
+    """Capture weight readings from a camera pointed at a digital scale.
+
+    Args:
+        output_csv: Path to CSV file where readings will be stored.
+        display_roi: Tuple (x, y, w, h) for cropping the region of interest containing the LCD display.
+        camera_index: Index of the camera to use.
+    """
+    cap = cv2.VideoCapture(camera_index)
+    if not cap.isOpened():
+        raise RuntimeError("Unable to open camera")
+
+    data = []
+    last_value = None
+
+    print("Press 'q' to quit...")
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            print("Failed to grab frame")
+            break
+
+        # Crop to display ROI if provided
+        if display_roi is not None:
+            x, y, w, h = display_roi
+            frame_roi = frame[y:y+h, x:x+w]
+        else:
+            frame_roi = frame
+
+        gray = cv2.cvtColor(frame_roi, cv2.COLOR_BGR2GRAY)
+        # Threshold to make text more distinct
+        _, thresh = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+
+        # Use pytesseract to do OCR on digits only
+        config = "--psm 7 -c tessedit_char_whitelist=0123456789.-"
+        text = pytesseract.image_to_string(thresh, config=config)
+        text = text.strip()
+
+        # Show for debugging
+        cv2.imshow('Scale ROI', frame_roi)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+        # If the OCR result is non-empty and changed, record
+        if text and text != last_value:
+            timestamp = datetime.now().isoformat()
+            print(f"{timestamp}: {text}")
+            data.append({'timestamp': timestamp, 'weight': text})
+            last_value = text
+
+    cap.release()
+    cv2.destroyAllWindows()
+    if data:
+        df = pd.DataFrame(data)
+        df.to_csv(output_csv, index=False)
+        # Also save to Excel for convenience
+        excel_path = output_csv.rsplit('.', 1)[0] + '.xlsx'
+        df.to_excel(excel_path, index=False)
+        print(f"Saved {len(data)} readings to {output_csv} and {excel_path}")
+    else:
+        print("No data captured")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Record digital scale readings via camera")
+    parser.add_argument('output', help='Output CSV file path')
+    parser.add_argument('--roi', type=int, nargs=4, metavar=('X','Y','W','H'),
+                        help='ROI of LCD display (x y w h)')
+    parser.add_argument('--camera', type=int, default=0, help='Camera index (default 0)')
+    args = parser.parse_args()
+
+    capture_scale(args.output, display_roi=tuple(args.roi) if args.roi else None,
+                  camera_index=args.camera)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a `scale_reader.py` utility to capture weight values via webcam
- save weight changes with timestamps to CSV and Excel
- include wrapper `main` script for convenience
- document usage and requirements
- specify Python package requirements

## Testing
- `python scale_reader.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6854090d77388320845581d6ed42ada2