### PR TITLE
Add extra padding for OCR

### DIFF
--- a/scale_reader.py
+++ b/scale_reader.py
@@ -49,6 +49,9 @@ def preprocess_for_ocr(crop):
     # 6) Upscale 2× for Tesseract
     binary = cv2.resize(binary, None, fx=2, fy=2,
                         interpolation=cv2.INTER_CUBIC)
+    # 7) Add another 10px white border to avoid boundary artifacts
+    binary = cv2.copyMakeBorder(binary, 10,10,10,10,
+                                cv2.BORDER_CONSTANT, value=255)
     return binary
 
 


### PR DESCRIPTION
## Summary
- avoid boundary artifacts by adding a second white border after scaling

## Testing
- `python -m py_compile scale_reader.py`
- `python scale_reader.py --help` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6859418d6d888320aaa5ba4dccf0dbd7